### PR TITLE
Correct repository language type by ignoring vendor and output files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -64,3 +64,5 @@
 
 # github linguist ignore vendor packages to correct rrpository language type
 packages/* linguist-vendored
+App1/App1.Android/obj/* linguist-vendored
+App1/App1.iOS/obj/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,6 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+# github linguist ignore vendor packages to correct rrpository language type
+packages/* linguist-vendored


### PR DESCRIPTION
The `obj` directories should likely be added to .gitignore and not committed at all, although I can't say for certain since I didn't look too deeply